### PR TITLE
Fix unread messages name and clarify stand-up rules

### DIFF
--- a/scrumagent/build_agent_graph.py
+++ b/scrumagent/build_agent_graph.py
@@ -24,6 +24,8 @@ load_dotenv()
 ACTIVATE_DEEPSEEK = os.getenv("ACTIVATE_DEEPSEEK", "").lower() in ("true", "1", "yes", "on")
 
 def human_input_node(state: State) -> Command[Literal["supervisor"]]:
+    """Wait for user input and return to the supervisor node."""
+
     # It doesn't work like expected. It doesn't wait for the user input.
     # But it continues with the next invoke, so its fine I guess.
     human_message = interrupt("human_input")
@@ -50,6 +52,8 @@ def human_input_node(state: State) -> Command[Literal["supervisor"]]:
 #     )
 
 def web_node(state: State) -> Command[Literal["supervisor"]]:
+    """Invoke the research agent and pass the result back to the supervisor."""
+
     result = research_agent.invoke(state)
     print(f"Web Agent response: {result['messages'][-1].content}")
     return Command(
@@ -63,6 +67,8 @@ def web_node(state: State) -> Command[Literal["supervisor"]]:
 
 
 def llm_node(state: State) -> Command[Literal["supervisor"]]:
+    """Invoke the DeepSeek LLM agent and return its response."""
+
     result = llm_agent.invoke(state)
     print(f"Deepseek response: {result['messages'][-1].content}")
     return Command(
@@ -76,6 +82,8 @@ def llm_node(state: State) -> Command[Literal["supervisor"]]:
 
 
 def discord_search_node(state: State) -> Command[Literal["supervisor"]]:
+    """Invoke the Discord search agent and return its response."""
+
     result = discord_search_agent.invoke(state)
     print(f"Discord Agent response: {result['messages'][-1].content}")
     return Command(
@@ -89,6 +97,8 @@ def discord_search_node(state: State) -> Command[Literal["supervisor"]]:
 
 
 def taiga_node(state: State) -> Command[Literal["supervisor"]]:
+    """Invoke the Taiga agent and forward its response."""
+
     print("Taiga Agent invoked state: " + state["messages"][-1].content)
     result = taiga_agent.invoke(state)
     print(f"Taiga Agent response: {result['messages'][-1].content}")
@@ -103,9 +113,7 @@ def taiga_node(state: State) -> Command[Literal["supervisor"]]:
 
 
 def time_parser_node(state: State) -> Command[Literal["supervisor"]]:
-    """
-    Node that invokes the interpret_timeframe_tool on the user's last message.
-    """
+    """Parse natural language timeframes in the user's last message."""
     # 1) Extract the user query (raw_timeframe) from 'state'
     #    For example, if the last message from the user was "parse '2 weeks ago'".
     user_message = state["messages"][-1].content
@@ -125,9 +133,7 @@ def time_parser_node(state: State) -> Command[Literal["supervisor"]]:
 
 
 def current_timestamp_node(state: State) -> Command[Literal["supervisor"]]:
-    """
-    Node that invokes the current_timestamp_tool to get the current timestamp.
-    """
+    """Return the current timestamp via the helper tool."""
 
     # 1) Call the current timestamp tool
     timestamp_str = current_timestamp_tool()
@@ -144,6 +150,7 @@ def current_timestamp_node(state: State) -> Command[Literal["supervisor"]]:
 
 
 def build_graph():
+    """Compile and return the multi‑agent LangGraph."""
     # https://langchain-ai.github.io/langgraph/concepts/persistence/#using-in-langgraph
     # TODO!: Add the in-memory store to the graph + search for the in-memory store.
 

--- a/scrumagent/data_collector/base_collector.py
+++ b/scrumagent/data_collector/base_collector.py
@@ -4,6 +4,8 @@ from langchain_core.documents import Document
 
 
 class BaseCollector:
+    """Base class for collecting data and storing it in Chroma."""
+
     # DB_IDENTIFIER is used to identify the source of the data in the DB
     # Add as source in the metadata of the document
     # And in front of the ID of the document
@@ -11,20 +13,35 @@ class BaseCollector:
     DB_IDENTIFIER = "base"
 
     def __init__(self, bot: discord.Client, db: Chroma):
+        """Create a new collector.
+
+        Args:
+            bot (discord.Client): Discord client instance.
+            db (Chroma): Chroma database handle.
+        """
+
         self.bot = bot
         self.db = db
 
     async def on_startup(self):
+        """Hook that is called once the bot is ready."""
+
         raise NotImplementedError
 
     def add_to_db(self, _id: str, text: str, metadata: {}) -> [str]:
+        """Add a single document to the database."""
+
         return self.add_to_db_batch(ids=[_id], texts=[text], metadatas=[metadata])
 
     def add_to_db_batch(self, ids: [str], texts: [str], metadatas: [{}]) -> [str]:
+        """Add multiple documents to the database."""
+
         print(f"Adding {len(ids)} docs to the DB")
         return self.db.add_texts(texts=texts, metadatas=metadatas, ids=ids)
 
     def add_to_db_docs(self, docs: [Document], ids: [str] = None) -> [str]:
+        """Store ``docs`` in the database."""
+
         texts = [doc.page_content for doc in docs]
         metadatas = [doc.metadata for doc in docs]
         return self.add_to_db_batch(ids=ids, texts=texts, metadatas=metadatas)

--- a/scrumagent/data_collector/folder_documents_collector.py
+++ b/scrumagent/data_collector/folder_documents_collector.py
@@ -11,9 +11,19 @@ from .base_collector import BaseCollector
 
 
 class DirectoryCollector(BaseCollector):
+    """Collect text files from a folder and store them in Chroma."""
+
     DB_IDENTIFIER = "folder_doc"
 
     def __init__(self, bot: discord.Client, chroma_db: Chroma, folder_path: Union[Path, str]):
+        """Create the directory collector.
+
+        Args:
+            bot (discord.Client): Discord client instance.
+            chroma_db (Chroma): Database handle.
+            folder_path (Path | str): Path to the folder to scan.
+        """
+
         self.folder_path = str(folder_path)
 
         # Used by DirectoryLoader ...
@@ -25,13 +35,16 @@ class DirectoryCollector(BaseCollector):
         super().__init__(bot, chroma_db)
 
     async def on_startup(self):
+        """Load all files when the bot starts."""
+
         await self.check_all_files_in_folder()
 
     async def check_all_files_in_folder(self):
+        """Load all text files from the configured folder."""
+
         loader = DirectoryLoader(self.folder_path, glob="**/*.txt")
         docs = loader.load()
-        ids = [f"{self.DB_IDENTIFIER}_{hashlib.md5(doc.metadata['source'].encode('UTF-8')).hexdigest()}" for doc in
-               docs]
+        ids = [f"{self.DB_IDENTIFIER}_{hashlib.md5(doc.metadata['source'].encode('UTF-8')).hexdigest()}" for doc in docs]
 
         for doc in docs:
             doc.metadata["source"] = self.DB_IDENTIFIER

--- a/scrumagent/main_discord_bot.py
+++ b/scrumagent/main_discord_bot.py
@@ -86,6 +86,7 @@ data_collector_list = [discord_chat_collector]
 
 @util_logging.exception(__name__)
 def run_agent_in_cb_context(messages: list, config: dict, cost_position=None) -> dict:
+    """Run the agent graph and track token costs."""
     with get_openai_callback() as cb:
         result = multi_agent_graph.invoke(
             {"messages": messages},
@@ -105,6 +106,7 @@ def run_agent_in_cb_context(messages: list, config: dict, cost_position=None) ->
 @bot.event
 @util_logging.exception(__name__)
 async def on_message(message: discord.Message):
+    """Handle incoming Discord messages."""
     if message.author == bot.user:
         return
 
@@ -215,6 +217,7 @@ async def on_message(message: discord.Message):
 
 @util_logging.exception(__name__)
 async def manage_user_story_threads(project_slug: str):
+    """Ensure that each Taiga user story has a corresponding Discord thread."""
     print("Manage user story threads started.")
 
     project = get_project(project_slug)
@@ -340,8 +343,9 @@ async def manage_user_story_threads(project_slug: str):
 @bot.event
 @util_logging.exception(__name__)
 async def on_guild_join():
+    """Called when the bot joins a guild."""
     print(f"Guild join: {bot.user} (ID: {bot.user.id})")
-    await discord_chat_collector.check_all_unread_massages()
+    await discord_chat_collector.check_all_unread_messages()
 
 
 @bot.event
@@ -363,6 +367,7 @@ async def on_guild_update():
 @tasks.loop(hours=1)
 @util_logging.exception(__name__)
 async def update_taiga_threads():
+    """Periodic task that syncs Taiga user stories with Discord threads."""
     print("Updating taiga threads started.")
     for project_slug in TAIGA_SLAG_TO_DISCORD_CHANNEL_MAP.keys():
         await manage_user_story_threads(project_slug)
@@ -371,6 +376,7 @@ async def update_taiga_threads():
 @tasks.loop(hours=24)
 @util_logging.exception(__name__)
 async def daily_datacollector_task():
+    """Run daily housekeeping routines for data collection."""
     print("Daily data collector started.")
     # await blog_txt_collector.check_all_files_in_folder()
     pass
@@ -392,24 +398,13 @@ BERLIN_TZ = pytz.timezone("Europe/Berlin")
 
 
 def extract_tags(us: Any) -> set[str]:
-    """
-    Return all tag names of a Taiga user‑story in lower case.
+    """Return all tag names of a Taiga user story in lowercase.
 
-    The function accepts either:
-      • a JSON dict returned by `get_entity_by_ref_tool`, where the key
-        "tags" is a list of ["tag‑name", "color"] pairs, or
-      • a `taiga.models.UserStory` instance whose `.tags` attribute
-        is already a list of strings.
+    Args:
+        us (dict | taiga.models.UserStory): The user story object or its JSON representation.
 
-    Parameters
-    ----------
-    us : dict | taiga.models.UserStory
-        The user‑story object or its JSON representation.
-
-    Returns
-    -------
-    set[str]
-        A set containing all tag names in lowercase.
+    Returns:
+        set[str]: All tags associated with the user story.
     """
     if isinstance(us, dict):  # JSON from the tool
         return {t[0].lower() for t in us.get("tags", []) if t}
@@ -420,26 +415,24 @@ def extract_tags(us: Any) -> set[str]:
 
 
 def standup_due_today(us: Any) -> bool:
-    """
-    Determine whether a stand‑up message should be sent today for the
-    given user‑story, based on its tags.
+    """Return ``True`` if a stand‑up should be sent today.
 
-    Tag rules
-    ---------
-    • "daily stand-up"   – every day, including weekends
-    • "weekly stand-up"  – Mondays only
-    • no tag             – Monday to Friday (default)
+    The decision is based on the tags attached to the Taiga user
+    story:
 
-    Parameters
-    ----------
-    us : dict | taiga.models.UserStory
-        The user‑story object or its JSON representation.
+    - ``"daily stand-up"``    – a message is posted every day, including
+      weekends.
+    - ``"weekly stand-up"``   – only post on Mondays.
+    - no tag                  – default behaviour; post Monday through
+      Friday.
 
-    Returns
-    -------
-    bool
-        True  -> send stand‑up today
-        False -> skip for today
+    Args:
+        us (dict | taiga.models.UserStory): The user story object or its
+            JSON representation.
+
+    Returns:
+        bool: ``True`` if a stand‑up should be posted today, otherwise
+        ``False``.
     """
     tags = extract_tags(us)
     today_idx = datetime.datetime.now(BERLIN_TZ).weekday()  # 0 = Monday
@@ -451,6 +444,7 @@ def standup_due_today(us: Any) -> bool:
 @tasks.loop(time=datetime.time(hour=8, minute=0, tzinfo=pytz.timezone('Europe/Berlin')))
 @util_logging.exception(__name__)
 async def scrum_master_task():
+    """Daily task that posts stand-up messages."""
     print(f"Scrum master task started at {datetime.datetime.now()}")
     for project_slug in TAIGA_SLAG_TO_DISCORD_CHANNEL_MAP.keys():
         await manage_user_story_threads(project_slug)
@@ -497,6 +491,7 @@ async def scrum_master_task():
 @bot.event
 @util_logging.exception(__name__)
 async def on_ready():
+    """Called when the Discord bot is fully ready."""
     channel_list = [bot.get_channel(x) for x in DISCORD_LOG_CHANNEL]
     util_logging.override_defaults(override=channel_list)
     discord_log_worker.start()
@@ -522,6 +517,7 @@ async def on_ready():
 
 @tasks.loop(seconds=10)
 async def discord_log_worker():
+    """Forward log records from the queue to Discord."""
     try:
         subject, rec, discord_channels = util_logging.discord_log_queue.get_nowait()
     except util_logging.queue.Empty:

--- a/scrumagent/utils.py
+++ b/scrumagent/utils.py
@@ -11,18 +11,34 @@ mod_path = Path(__file__).parent
 
 
 def get_image_description_via_llama(image_path: str) -> str:
+    """Return a short description of the image at ``image_path``.
+
+    The function sends the image to an Ollama model and returns the
+    generated description.
+
+    Args:
+        image_path (str): Path to the image file.
+
+    Returns:
+        str: The text description produced by the model.
+    """
+
     response = ollama.chat(
-        model='llama3.2-vision',
-        messages=[{
-            'role': 'user',
-            'content': 'What is in this image?',
-            'images': [image_path]
-        }]
+        model="llama3.2-vision",
+        messages=[
+            {
+                "role": "user",
+                "content": "What is in this image?",
+                "images": [image_path],
+            }
+        ],
     )
-    return response['message']['content']
+    return response["message"]["content"]
 
 
 def init_discord_chroma_db():
+    """Initialise and return the Chroma database for Discord logs."""
+
     # embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
     CHROMA_PATH = str(mod_path / os.getenv("CHROMA_DB_PATH"))
     CHROMA_DB_DISCORD_CHAT_DATA_NAME = os.getenv("CHROMA_DB_DISCORD_CHAT_DATA_NAME")
@@ -42,14 +58,18 @@ def init_discord_chroma_db():
 
 
 def split_text_smart(text, max_length=2000):
-    """
-    Splits a given text into sections of up to max_length characters,
-    preserving paragraph and list item boundaries when possible.
-    (Generated with ChatGPT...)
+    """Split ``text`` into chunks of at most ``max_length`` characters.
 
-    :param text: The input text to be split.
-    :param max_length: The maximum allowed length per section.
-    :return: A list of text sections.
+    The function tries to keep paragraphs and list items intact when
+    splitting the text.
+
+    Args:
+        text (str): The input string.
+        max_length (int, optional): Maximum length of each chunk. Defaults to
+            ``2000``.
+
+    Returns:
+        list[str]: The resulting list of text segments.
     """
     if len(text) <= max_length:
         return [text]


### PR DESCRIPTION
## Summary
- rename the unread messages helper
- document when stand-up posts are triggered

## Testing
- `python -m compileall -q scrumagent`
