### PR TITLE
Ignore group mentions

### DIFF
--- a/scrumagent/main_discord_bot.py
+++ b/scrumagent/main_discord_bot.py
@@ -305,9 +305,17 @@ async def on_message(message: discord.Message) -> None:
     if attachments_prepared:
         question_format += "\nAttachments:\n" + "\n".join(attachments_prepared)
 
-    # If the bot is not mentioned in the message, add the question to the state of the multi-agent graph.
+    # Determine if the bot was explicitly mentioned in the message. ``User.mentioned_in``
+    # also returns ``True`` for ``@here`` or ``@everyone`` mentions, which should not
+    # trigger the bot. Therefore we explicitly check if the bot user is in the
+    # ``message.mentions`` list.
+    bot_explicitly_mentioned = bot.user in message.mentions
+
+    # If the bot is not explicitly mentioned in the message and it is not a DM,
+    # just add the question to the state of the multi-agent graph without
+    # generating a reply.
     if (
-        not bot.user.mentioned_in(message)
+        not bot_explicitly_mentioned
         and type(message.channel) != discord.DMChannel
     ):
         print(f"Add question to state: {question_format}")


### PR DESCRIPTION
## Summary
- don't treat `@here` or `@everyone` as explicit mentions in Discord bot

## Testing
- `pytest -q` *(fails: ProxyError from test_web_agent_tools due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6846c7bb5c14832abd170e7a70c32082