### PR TITLE
Fix missing tags attribute in scrum master task

### DIFF
--- a/scrumagent/main_discord_bot.py
+++ b/scrumagent/main_discord_bot.py
@@ -447,9 +447,9 @@ def extract_tags(us: Any) -> set[str]:
     if isinstance(us, dict):  # JSON from the tool
         return {t[0].lower() for t in us.get("tags", []) if t}
     if isinstance(us, UserStory):
-        return {t[0].lower() for t in us.tags if t}
+        return {t[0].lower() for t in getattr(us, "tags", []) if t}
     # Python client object
-    return {t.lower() for t in us.tags}
+    return {t.lower() for t in getattr(us, "tags", [])}
 
 
 def standup_due_today(us: Any) -> bool:


### PR DESCRIPTION
## Summary
- avoid AttributeError when UserStory objects lack `tags`

## Testing
- `pytest -q` *(fails: ProxyError - export.arxiv.org, html.duckduckgo.com, en.wikipedia.org, youtube.com)*

------
https://chatgpt.com/codex/tasks/task_b_68638c1adab4832ab48cf3c50a9e6e53