### PR TITLE
Change default stand-up schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Below are examples showing **how to create and update Taiga issues or user stori
 |-----------------------------|---------------|------------------------------------------------------------------------------|
 | `daily stand‑up`            | Stand‑up **every day** (incl. weekends) | <img src="assets/daily_stand-up.png" alt="Tag field in Taiga" height="30"/>  |
 | `weekly stand‑up`           | Stand‑up **Mondays only**              | <img src="assets/weekly_stand-up.png" alt="Tag field in Taiga" height="30"/> |
-| _no tag_                    | Stand‑up **Monday–Friday** (default)   | —                                                                            |
+| _no tag_                    | Stand‑up **Mondays only** (default)   | —                                                                            |
 
 **How to use**
 

--- a/scrumagent/main_discord_bot.py
+++ b/scrumagent/main_discord_bot.py
@@ -468,8 +468,7 @@ def standup_due_today(us: Any) -> bool:
     - ``"daily stand-up"``    – a message is posted every day, including
       weekends.
     - ``"weekly stand-up"``   – only post on Mondays.
-    - no tag                  – default behaviour; post Monday through
-      Friday.
+    - no tag                  – default behaviour; post Mondays only.
 
     Args:
         us (dict | taiga.models.UserStory): The user story object or its
@@ -485,7 +484,7 @@ def standup_due_today(us: Any) -> bool:
         return True
     if "weekly stand-up" in tags:
         return today_idx == 0
-    return today_idx < 5
+    return today_idx == 0
 
 
 def get_active_user_stories(project: Any) -> List[UserStory]:


### PR DESCRIPTION
## Summary
- change default stand-up schedule to weekly
- document new default behaviour

## Testing
- `pytest -q` *(fails: ProxyError while accessing export.arxiv.org, lite.duckduckgo.com, html.duckduckgo.com, en.wikipedia.org, youtube.com)*

------
https://chatgpt.com/codex/tasks/task_b_6865033ce3a0832aa810765141ace27f