### PR TITLE
Add opt-out tag for stand-up scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,14 +243,15 @@ Below are examples showing **how to create and update Taiga issues or user stori
 | Tag on the Taiga user story | Bot behaviour | Where to add it                                                              |
 |-----------------------------|---------------|------------------------------------------------------------------------------|
 | `daily stand‑up`            | Stand‑up **every day** (incl. weekends) | <img src="assets/daily_stand-up.png" alt="Tag field in Taiga" height="30"/>  |
-| `weekly stand‑up`           | Stand‑up **Mondays only**              | <img src="assets/weekly_stand-up.png" alt="Tag field in Taiga" height="30"/> |
-| _no tag_                    | Stand‑up **Mondays only** (default)   | —                                                                            |
+| `weekly stand‑up`           | Stand‑up **Mondays only**              | <img src="assets/weekly stand-up.png" alt="Tag field in Taiga" height="30"/> |
+| `no stand‑up`              | **No stand‑up**                        | — |
+| _no tag_                    | Stand‑up **Mondays only** (default)   | — |
 
 **How to use**
 
-1. Open the user story in **Taiga**.  
-2. In the **Tags** field add either `daily stand‑up` or `weekly stand‑up`.  
-3. If neither tag is set, the bot automatically posts on weekdays.
+1. Open the user story in **Taiga**.
+2. In the **Tags** field add either `daily stand‑up`, `weekly stand‑up`, or `no stand‑up`.
+3. If none of these tags is set, the bot automatically posts on Mondays.
 
 _No extra configuration needed – this logic is built into the bot._
 

--- a/scrumagent/main_discord_bot.py
+++ b/scrumagent/main_discord_bot.py
@@ -465,6 +465,7 @@ def standup_due_today(us: Any) -> bool:
     The decision is based on the tags attached to the Taiga user
     story:
 
+    - ``"no stand-up"``       – never post a stand‑up.
     - ``"daily stand-up"``    – a message is posted every day, including
       weekends.
     - ``"weekly stand-up"``   – only post on Mondays.
@@ -480,6 +481,8 @@ def standup_due_today(us: Any) -> bool:
     """
     tags = extract_tags(us)
     today_idx = datetime.datetime.now(BERLIN_TZ).weekday()  # 0 = Monday
+    if "no stand-up" in tags:
+        return False
     if "daily stand-up" in tags:
         return True
     if "weekly stand-up" in tags:

--- a/tests/test_standup_schedule.py
+++ b/tests/test_standup_schedule.py
@@ -1,0 +1,22 @@
+import datetime
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault("CHROMA_DB_PATH", "chroma")
+os.environ.setdefault("CHROMA_DB_DISCORD_CHAT_DATA_NAME", "discord-test")
+
+from scrumagent.main_discord_bot import standup_due_today
+
+
+class Monday(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2024, 12, 30, tzinfo=tz)
+
+
+def test_no_standup_tag_skips_posting():
+    """User stories tagged with ``no stand-up`` should not trigger messages."""
+    us = SimpleNamespace(tags=["no stand-up"])
+    with patch("scrumagent.main_discord_bot.datetime.datetime", Monday):
+        assert standup_due_today(us) is False


### PR DESCRIPTION
## Summary
- add `no stand-up` tag so stories can opt out of stand-up posts
- document all available tags for stand-up scheduling
- test skipping stand-ups when `no stand-up` tag is present

## Testing
- `pytest tests/test_standup_schedule.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b55c00f1e8832ab20d1dc0505df11e